### PR TITLE
Feature/last updated

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -21,6 +21,7 @@ export default defineConfigWithTheme<ThemeConfig>({
     markdown: {
         math: true
     },
+    lastUpdated: true,
     vite: {
         plugins: [
             // @ts-ignore
@@ -188,5 +189,6 @@ export default defineConfigWithTheme<ThemeConfig>({
         next: "下一页",
         prev: "上一页",
         enableVitrual: true,
+        timeLabel: "上次更新于：:lYYYY/:lMM/:lDD  创建于：:cYYYY/:cMM/:cDD"
     },
 })

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -181,6 +181,13 @@ export default defineConfigWithTheme<ThemeConfig>({
             tag: {
                 format: (tag) => `# ${tag}`
             },
+            panelTabHistory: {
+                repository: "https://github.com/cell-juicy/cell-juicy.github.io",
+                interval: "month",
+                intervalFormat(date) {
+                    return `${date.getFullYear()}年${date.getMonth() + 1}月`
+                },
+            }
         },
         editLink: {
             pattern: "https://github.com/cell-juicy/cell-juicy.github.io/tree/main/docs/:path",

--- a/docs/.vitepress/theme/VPJLayout.vue
+++ b/docs/.vitepress/theme/VPJLayout.vue
@@ -4,6 +4,7 @@ import { nextTick, watch, onMounted, onUnmounted } from 'vue';
 
 import VPJSidebar from './components/VPJSidebar.vue';
 import VPJMobileNavbar from './components/VPJMobileNavbar.vue';
+import VPJPanel from './components/VPJPanel.vue';
 
 import VPJContent from './layouts/VPJContent.vue';
 
@@ -85,6 +86,9 @@ onUnmounted(() => {
                 <template #doc-padding-right><slot name="doc-padding-right"/></template>
             </VPJContent>
         </div>
+        <VPJPanel>
+
+        </VPJPanel>
     </div>
 </template>
 

--- a/docs/.vitepress/theme/VPJLayout.vue
+++ b/docs/.vitepress/theme/VPJLayout.vue
@@ -14,9 +14,7 @@ function scrollToAnchor() {
         if (hash !== "") {
             nextTick(() => {
                 const target = document.getElementById(decodeURIComponent(hash.substring(1)));
-                if (target) {
-                    target.scrollIntoView({ behavior: "smooth" });
-                };
+                if (target) target.scrollIntoView({ behavior: "smooth" });
             });
         };
     };

--- a/docs/.vitepress/theme/components/VPJArticleAside.vue
+++ b/docs/.vitepress/theme/components/VPJArticleAside.vue
@@ -167,7 +167,7 @@ onUnmounted(() => {
 
     .vpj-article-aside.collapsed {
         width: 0;
-        border-right-color: transparent;
+        border-right: none;
     }
 
     .vpj-article-aside__header {

--- a/docs/.vitepress/theme/components/VPJArticleAsideOutlinePage.vue
+++ b/docs/.vitepress/theme/components/VPJArticleAsideOutlinePage.vue
@@ -56,9 +56,9 @@ useActiveAnchor(outline, scrollArea);
 <template>
     <VPJOverlayScrollArea
         overflow="y"
-        class="vpj-layout-blog__aside-tab-outer"
-        :area-attrs="{ class: 'vpj-layout-blog__aside-tab-area' }"
-        :inner-attrs="{ class: 'vpj-layout-blog__aside-tab-inner' }"
+        class="vpj-article-aside__aside-tab-outer"
+        :area-attrs="{ class: 'vpj-article-aside__aside-tab-area' }"
+        :inner-attrs="{ class: 'vpj-article-aside__aside-tab-inner' }"
     >
         <div
             v-if="headers.length === 0"
@@ -86,13 +86,13 @@ useActiveAnchor(outline, scrollArea);
 
 
 <style scoped>
-    .vpj-layout-blog__aside-tab-outer {
+    .vpj-article-aside__aside-tab-outer {
         background-color: var(--vpj-color-bg-100);
         height: 100%;
         width: 100%;
     }
 
-    :deep(.vpj-layout-blog__aside-tab-inner) {
+    :deep(.vpj-article-aside__aside-tab-inner) {
         align-items: center;
         display: flex;
         flex-direction: column;

--- a/docs/.vitepress/theme/components/VPJArticleFooter.vue
+++ b/docs/.vitepress/theme/components/VPJArticleFooter.vue
@@ -2,11 +2,13 @@
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 
+import { isDesktop } from '../utils/deviceTypes';
+
 import { useVPJLayout } from '../composables/useVPJLayout';
 
 import VPJIconArrowLeft from '../components/icons/VPJIconArrowLeft.vue';
 import VPJIconArrowRight from '../components/icons/VPJIconArrowRight.vue';
-import VPJIconEdit from '../components/icons/VPJIconEdit.vue'
+import VPJIconEdit from '../components/icons/VPJIconEdit.vue';
 
 
 const props = defineProps({
@@ -39,7 +41,7 @@ const computedMarginBottom = computed(() => {
 
 <template>
     <div
-        v-if="config.editLink.link || prev.link || next.link"
+        v-if="config.editLink.link || prev.link || next.link || config.timeLabel"
         class="vpj-article-footer"
     >
         <nav
@@ -86,6 +88,12 @@ const computedMarginBottom = computed(() => {
                     {{ config.editLink.text }}
                 </span>
             </a>
+            <span
+                v-if="config.timeLabel.length > 0 && isDesktop"
+                class="vpj-article-footer__time-label vpj-text"
+            >
+                {{ config.timeLabel }}
+            </span>
         </div>
     </div>
 </template>
@@ -176,18 +184,20 @@ const computedMarginBottom = computed(() => {
         text-align: right;
     }
 
-    /* Edit Link */
     .vpj-article-footer__info {
-        align-items: flex-start;
+        align-items: center;
         display: flex;
+        justify-content: space-between;
         width: 100%;
     }
 
+    /* Edit Link */
     .vpj-article-footer__edit-link {
         align-items: center;
         display: flex;
         gap: .5rem;
         height: 1rem;
+        margin-right: auto;
         text-decoration: none;
     }
 
@@ -210,6 +220,15 @@ const computedMarginBottom = computed(() => {
     .vpj-article-footer__edit-link:hover .vpj-article-footer__edit-link-text,
     .vpj-article-footer__edit-link:active .vpj-article-footer__edit-link-text {
         color: var(--vpj-color-primary-300);
+    }
+
+    /* Time Label */
+    .vpj-article-footer__time-label {
+        color: var(--vpj-color-text-200);
+        height: 1rem;
+        line-height: 1rem;
+        margin-left: auto;
+        text-align: right;
     }
 
     /* StyleSheet for mobile&tablet screen */

--- a/docs/.vitepress/theme/components/VPJArticleFooter.vue
+++ b/docs/.vitepress/theme/components/VPJArticleFooter.vue
@@ -14,11 +14,11 @@ import VPJIconEdit from '../components/icons/VPJIconEdit.vue';
 const props = defineProps({
     prev: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     next: {
         type: Object,
-        default: {}
+        default: () => ({})
     }
 })
 

--- a/docs/.vitepress/theme/components/VPJArticleFooter.vue
+++ b/docs/.vitepress/theme/components/VPJArticleFooter.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { storeToRefs } from 'pinia';
+import { computed } from 'vue';
 
 import { useVPJLayout } from '../composables/useVPJLayout';
 
@@ -21,13 +22,26 @@ const props = defineProps({
 
 const store = useVPJLayout();
 const {
-    articleFooterConfig: config
+    articleFooterConfig: config,
+    contentConfig: content,
+    footerConfig: footer
 } = storeToRefs(store);
+
+const computedMarginBottom = computed(() => {
+    const marginBottom = content.value.marginBottom || "0";
+    if (!(footer.value.message || footer.value.copyright)) {
+        return `min(${marginBottom}, 4.5rem)`
+    };
+    return ".5rem"
+})
 </script>
 
 
 <template>
-    <div class="vpj-article-footer">
+    <div
+        v-if="config.editLink.link || prev.link || next.link"
+        class="vpj-article-footer"
+    >
         <nav
             v-if="next.link || prev.link"
             class="vpj-article-footer__navgation"
@@ -55,7 +69,7 @@ const {
                 <VPJIconArrowRight class="vpj-article-footer__navgation-icon"/>
             </a>
         </nav>
-        <div class="vpj-article-footer__edit-info">
+        <div class="vpj-article-footer__info">
             <a
                 v-if="config.editLink.link"
                 :href="config.editLink.link"
@@ -83,12 +97,13 @@ const {
         flex-direction: column;
         flex-shrink: 0;
         gap: 1.25rem;
-        margin-bottom: .5rem;
+        margin-bottom: v-bind(computedMarginBottom);
     }
 
     .vpj-article-footer__navgation {
         align-items: center;
         display: flex;
+        flex-direction: row;
         flex-shrink: 0;
         gap: 1rem;
         width: 100%;
@@ -162,7 +177,7 @@ const {
     }
 
     /* Edit Link */
-    .vpj-article-footer__edit-info {
+    .vpj-article-footer__info {
         align-items: flex-start;
         display: flex;
         width: 100%;
@@ -178,6 +193,7 @@ const {
 
     .vpj-article-footer__edit-link-icon {
         fill: var(--vpj-color-primary-400);
+        flex-shrink: 0;
         height: 1rem;
         width: 1rem;
     }
@@ -194,5 +210,17 @@ const {
     .vpj-article-footer__edit-link:hover .vpj-article-footer__edit-link-text,
     .vpj-article-footer__edit-link:active .vpj-article-footer__edit-link-text {
         color: var(--vpj-color-primary-300);
+    }
+
+    /* StyleSheet for mobile&tablet screen */
+    @media screen and (max-width: 1024px) {
+        .vpj-article-footer__navgation {
+            flex-direction: column;
+        }
+
+        .vpj-article-footer__navgation-prev,
+        .vpj-article-footer__navgation-next {
+            width: 100%;
+        }
     }
 </style>

--- a/docs/.vitepress/theme/components/VPJArticleFooter.vue
+++ b/docs/.vitepress/theme/components/VPJArticleFooter.vue
@@ -89,7 +89,7 @@ const computedMarginBottom = computed(() => {
                 </span>
             </a>
             <span
-                v-if="config.timeLabel.length > 0 && isDesktop"
+                v-if="config.timeLabel && isDesktop"
                 class="vpj-article-footer__time-label vpj-text"
             >
                 {{ config.timeLabel }}

--- a/docs/.vitepress/theme/components/VPJArticleHeader.vue
+++ b/docs/.vitepress/theme/components/VPJArticleHeader.vue
@@ -1,5 +1,4 @@
 <script setup>
-import { useData } from 'vitepress';
 import { computed } from 'vue';
 
 import VPJDynamicIcon from './VPJDynamicIcon.vue'
@@ -34,6 +33,7 @@ const tooltipAttrs = {
         paddingBottom: ".375rem",
         paddingLeft: ".5rem",
         paddingRight: ".5rem",
+        zIndex: "102"
     }
 }
 
@@ -135,13 +135,14 @@ const showDivider = computed(() => {
                             :href="props.config?.github?.url"
                             :isLink="true"
                             :icon="VPJIconGithub"
-                            target="_blank"
                             :tooltip="props.config?.github?.tooltip"
                             :tooltipPosition="tooltipPosition"
                             :tooltipAttrs="tooltipAttrs"
                             :offset="tooltipOffset"
                             :safeMargin="tooltipSafeMargin"
                             class="vpj-article-header__button"
+                            target="_blank"
+                            rel="noopener"
                         />
                         <VPJTooltipBtn
                             v-if="props.config?.pdf?.url"
@@ -162,6 +163,7 @@ const showDivider = computed(() => {
                             :offset="tooltipOffset"
                             :safeMargin="tooltipSafeMargin"
                             class="vpj-article-header__button"
+                            rel="noopener"
                         />
                         <VPJTooltipBtn
                             v-if="props.config?.md?.url"
@@ -182,6 +184,7 @@ const showDivider = computed(() => {
                             :offset="tooltipOffset"
                             :safeMargin="tooltipSafeMargin"
                             class="vpj-article-header__button"
+                            rel="noopener"
                         />
                         <div v-if="showDivider" class="vpj-article-header__divider"/>
                         <VPJTooltipBtn
@@ -196,6 +199,7 @@ const showDivider = computed(() => {
                             :safeMargin="tooltipSafeMargin"
                             @click="tool.callback"
                             class="vpj-article-header__button"
+                            rel="noopener"
                         />
                     </div>
                 </Teleport>

--- a/docs/.vitepress/theme/components/VPJArticleHeader.vue
+++ b/docs/.vitepress/theme/components/VPJArticleHeader.vue
@@ -1,5 +1,8 @@
 <script setup>
 import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useVPJLayout } from '../composables/useVPJLayout';
 
 import VPJDynamicIcon from './VPJDynamicIcon.vue'
 import VPJDynamicIconBtn from './VPJDynamicIconBtn.vue';
@@ -12,6 +15,11 @@ import VPJIconPDF from './icons/VPJIconPDF.vue';
 
 import { isMobile, isTablet, isDesktop } from '../utils/deviceTypes'
 
+
+const store = useVPJLayout();
+const {
+    articleFooterConfig,
+} = storeToRefs(store);
 
 const tooltipPosition = "bottom"
 const tooltipBoundary = ".vpj-layout-content"
@@ -80,7 +88,8 @@ const toolsData = computed(() => {
 const showActions = computed(() => {
     const hasDefaults = !!props.config?.github?.url 
         || !!props.config?.pdf?.url 
-        || !!props.config?.md?.url;
+        || !!props.config?.md?.url
+        || !!articleFooterConfig.value.timeLabel;
     
     const hasTools = Object.entries(props.config?.toolbar || {}).length > 0;
 
@@ -210,7 +219,12 @@ const showDivider = computed(() => {
             v-show="!isDesktop && showActions"
             class="vpj-article-header__actions"
         >
-            
+            <span
+                v-if="articleFooterConfig.timeLabel.length > 0 && !isDesktop"
+                class="vpj-article-header__time-label vpj-text"
+            >
+                {{ articleFooterConfig.timeLabel }}
+            </span>
         </div>
         <slot name="header-after"/>
     </header>
@@ -329,6 +343,15 @@ const showDivider = computed(() => {
         width: 1px;
         margin-left: .25rem;
         margin-right: .25rem;
+    }
+
+    /* Time Label */
+    .vpj-article-header__time-label {
+        color: var(--vpj-color-text-200);
+        height: 1rem;
+        line-height: 1rem;
+        margin-left: 1rem;
+        text-align: right;
     }
 
     /* Tablet and Mobile style sheet */

--- a/docs/.vitepress/theme/components/VPJArticleHeader.vue
+++ b/docs/.vitepress/theme/components/VPJArticleHeader.vue
@@ -1,4 +1,5 @@
 <script setup>
+import { useData } from 'vitepress';
 import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 
@@ -12,6 +13,7 @@ import VPJIconGithub from './icons/VPJIconGithub.vue';
 import VPJIconMarkdown from './icons/VPJIconMarkdown.vue';
 import VPJIconMenuBurger from './icons/VPJIconMenuBurger.vue';
 import VPJIconPDF from './icons/VPJIconPDF.vue';
+import VPJIconTimePast from './icons/VPJIconTimePast.vue'
 
 import { isMobile, isTablet, isDesktop } from '../utils/deviceTypes'
 
@@ -20,6 +22,7 @@ const store = useVPJLayout();
 const {
     articleFooterConfig,
 } = storeToRefs(store);
+const { panelToggle } = store;
 
 const tooltipPosition = "bottom"
 const tooltipBoundary = ".vpj-layout-content"
@@ -138,6 +141,18 @@ const showDivider = computed(() => {
                     :disabled="isDesktop || !showActions"
                 >
                     <div class="vpj-article-header__toolbar">
+                        <VPJTooltipBtn
+                            @click="() => panelToggle('history')"
+                            :boundary="tooltipBoundary"
+                            :isLink="false"
+                            :icon="VPJIconTimePast"
+                            tooltip="查看历史记录"
+                            :tooltipPosition="tooltipPosition"
+                            :tooltipAttrs="tooltipAttrs"
+                            :offset="tooltipOffset"
+                            :safeMargin="tooltipSafeMargin"
+                            class="vpj-article-header__button"
+                        />
                         <VPJTooltipBtn
                             v-if="props.config?.github?.url"
                             :boundary="tooltipBoundary"

--- a/docs/.vitepress/theme/components/VPJArticleHeader.vue
+++ b/docs/.vitepress/theme/components/VPJArticleHeader.vue
@@ -220,7 +220,7 @@ const showDivider = computed(() => {
             class="vpj-article-header__actions"
         >
             <span
-                v-if="articleFooterConfig.timeLabel.length > 0 && !isDesktop"
+                v-if="articleFooterConfig.timeLabel && !isDesktop"
                 class="vpj-article-header__time-label vpj-text"
             >
                 {{ articleFooterConfig.timeLabel }}

--- a/docs/.vitepress/theme/components/VPJOverlayScrollArea.vue
+++ b/docs/.vitepress/theme/components/VPJOverlayScrollArea.vue
@@ -9,11 +9,11 @@ const props = defineProps({
     },
     areaAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     innerAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     tag: {
         type: String,
@@ -25,11 +25,11 @@ const props = defineProps({
     },
     trackXAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     trackYAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     thumbWidth: {
         type: String,
@@ -45,11 +45,11 @@ const props = defineProps({
     },
     thumbXAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     thumbYAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     }
 });
 

--- a/docs/.vitepress/theme/components/VPJPanel.vue
+++ b/docs/.vitepress/theme/components/VPJPanel.vue
@@ -1,0 +1,200 @@
+<script setup>
+import { useData } from 'vitepress';
+import { ref, computed, watch, onUnmounted } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useVPJLayout } from '../composables/useVPJLayout';
+
+import { isMobile, isTablet, isDesktop } from '../utils/deviceTypes';
+
+import VPJOverlayScrollArea from './VPJOverlayScrollArea.vue';
+import VPJDynamicIconBtn from './VPJDynamicIconBtn.vue';
+
+import VPJIconCrossSmall from './icons/VPJIconCrossSmall.vue';
+
+
+const store = useVPJLayout();
+const { panelCollapsed, panelTab } = storeToRefs(store);
+const {
+    panelClose
+} = store;
+
+const title = computed(() => {
+    switch (panelTab.value) {
+        case "history":
+            return "历史提交"
+        default:
+            return ""
+    }
+})
+</script>
+
+
+<template>
+    <Teleport
+        to=".vpj-portals-root"
+        :disabled="!isMobile"
+    >
+        <aside
+            :class="[
+                'vpj-panel',
+                { 'collapsed': panelCollapsed }
+            ]"
+        >
+            <header class="vpj-panel__header">
+                <span class="vpj-panel__title vpj-text">
+                    {{ title }}
+                </span>
+                <VPJDynamicIconBtn
+                    @click="panelClose"
+                    :icon="VPJIconCrossSmall"
+                    class="vpj-panel__close"
+                />
+            </header>
+            <div class="vpj-panel__content">
+                <div v-if="panelTab === 'history'"></div>
+            </div>
+        </aside>
+        <Transition>
+            <div
+                v-if="!isDesktop && !panelCollapsed"
+                @click="panelClose"
+                class="vpj-panel__overlay"
+            />
+        </Transition>
+    </Teleport>
+</template>
+
+
+<style scoped>
+    /* Main Layout */
+    .vpj-panel {
+        background-color: var(--vpj-color-bg-100);
+        border-left-width: var(--vpj-border-width-200);
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
+        height: 100%;
+        overflow: hidden;
+        transition:
+            transform 0.2s ease-in-out,
+            width 0.2s ease-in-out;
+        width: min(21.5rem, 35vw);
+    }
+
+    .vpj-panel.collapsed {
+        width: 0;
+        border-left: none;
+    }
+
+    .vpj-panel__header {
+        align-items: center;
+        border-bottom-width: var(--vpj-border-width-200);
+        display: flex;
+        flex-shrink: 0;
+        height: 2.75rem;
+        padding-bottom: .5rem;
+        padding-left: .875rem;
+        padding-right: .5rem;
+        padding-top: .5rem;
+        width: 100%;
+    }
+
+    .vpj-panel__content {
+        flex: 1;
+        width: 100%;
+    }
+
+    /* Title */
+    .vpj-panel__title {
+        flex: 1;
+        font-size: 1rem;
+        font-weight: var(--vpj-font-weight-600);
+        user-select: none;
+    }
+    
+
+    /* Close Button */
+    .vpj-panel__close {
+        align-items: center;
+        background-color: var(--vpj-color-bg-100);
+        border-radius: var(--vpj-border-radius-100);
+        display: flex;
+        height: 1.75rem;
+        padding: .375rem;
+        text-decoration: none;
+        width: 1.75rem;
+    }
+
+    .vpj-panel__close :deep(.vpj-icon) {
+        fill: var(--vpj-color-text-300);
+        height: 1rem;
+        width: 1rem;
+    }
+
+    .vpj-panel__close:hover,
+    .vpj-panel__close:active {
+        background-color: var(--vpj-color-bg-300);
+    }
+
+    .vpj-panel__close:hover :deep(.vpj-icon),
+    .vpj-panel__close:active :deep(.vpj-icon) {
+        fill: var(--vpj-color-text-400);
+    }
+
+    /* Overlay */
+    .vpj-panel__overlay {
+        display: block;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        top: 0;
+        z-index: 100;
+    }
+
+    /* Tablet style sheet */
+    @media (max-width: 1024px) {
+        .vpj-panel {
+            position: fixed;
+            bottom: 0;
+            right: 0;
+            top: 0;
+            height: 100vh;
+            width: min(20rem, 50vw);
+            z-index: 101;
+        }
+
+        /* Collapsed */
+        .vpj-panel.collapsed {
+            transform: translateX(100%);
+        }
+
+        /* Overlay */
+        .vpj-panel__overlay {
+            position: fixed;
+            background-color: transparent;
+        }
+    }
+
+    @media (max-width: 768px) {
+        /* Overlay */
+        .vpj-panel__overlay {
+            background-color: var(--vpj-overlay-400);
+        }
+    }
+
+    .v-enter-from,
+    .v-leave-to {
+        opacity: 0;
+    }
+
+    .v-enter-to,
+    .v-leave-from {
+        opacity: 1;
+    }
+
+    .v-enter-active,
+    .v-leave-active {
+        transition: opacity 0.2s ease-in-out;
+    }
+</style>

--- a/docs/.vitepress/theme/components/VPJPanel.vue
+++ b/docs/.vitepress/theme/components/VPJPanel.vue
@@ -1,6 +1,5 @@
 <script setup>
-import { useData } from 'vitepress';
-import { ref, computed, watch, onUnmounted } from 'vue';
+import { ref, computed } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useVPJLayout } from '../composables/useVPJLayout';
@@ -8,6 +7,7 @@ import { useVPJLayout } from '../composables/useVPJLayout';
 import { isMobile, isTablet, isDesktop } from '../utils/deviceTypes';
 
 import VPJDynamicIconBtn from './VPJDynamicIconBtn.vue';
+import VPJPanelHistoryPage from './VPJPanelHistoryPage.vue';
 
 import VPJIconCrossSmall from './icons/VPJIconCrossSmall.vue';
 
@@ -51,7 +51,7 @@ const title = computed(() => {
                 />
             </header>
             <div class="vpj-panel__content">
-                <div v-if="panelTab === 'history'"></div>
+                <VPJPanelHistoryPage v-if="panelTab === 'history'"/>
             </div>
         </aside>
         <Transition>
@@ -149,6 +149,29 @@ const title = computed(() => {
         right: 0;
         top: 0;
         z-index: 100;
+    }
+
+    /* Fallback */
+    :deep(.vpj-panel__fallback) {
+        align-items: center;
+        color: var(--vpj-color-text-100);
+        display: flex;
+        flex: 1;
+        font-size: 1.25rem;
+        height: 100%;
+        justify-content: center;
+        line-height: 1.5;
+        min-height: 0;
+        min-width: 0;
+        opacity: v-bind(fallbackOpacity);
+        overflow: hidden;
+        overflow-wrap: break-word;
+        padding-left: 1.2rem;
+        padding-right: 1.2rem;
+        transition: opacity 0.2s ease-in-out;
+        user-select: none;
+        width: 100%;
+        word-break: break-all;
     }
 
     /* Tablet style sheet */

--- a/docs/.vitepress/theme/components/VPJPanel.vue
+++ b/docs/.vitepress/theme/components/VPJPanel.vue
@@ -7,7 +7,6 @@ import { useVPJLayout } from '../composables/useVPJLayout';
 
 import { isMobile, isTablet, isDesktop } from '../utils/deviceTypes';
 
-import VPJOverlayScrollArea from './VPJOverlayScrollArea.vue';
 import VPJDynamicIconBtn from './VPJDynamicIconBtn.vue';
 
 import VPJIconCrossSmall from './icons/VPJIconCrossSmall.vue';

--- a/docs/.vitepress/theme/components/VPJPanelHistoryItem.vue
+++ b/docs/.vitepress/theme/components/VPJPanelHistoryItem.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed } from 'vue';
+import { computed } from 'vue'
 
 const props = defineProps({
     path: {
@@ -10,37 +10,43 @@ const props = defineProps({
         type: String,
         required: true
     },
-    info: {
+    commit: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     repository: {
-        type: String
+        type: [String, undefined]
     }
-});
+})
+
 const DEFAULT = {
     ACTION: {
         A: "添加",
         M: "修改",
         D: "删除",
         R: "重命名",
-        C: "复制",
-        U: "未知"
-    }
+        C: "复制"
+    },
+    BASENAME: (p) => p?.split(/[\\/]/).pop() || p || ""
 }
 
 const action = computed(() => {
-    return DEFAULT.ACTION[props.info.status] || DEFAULT.ACTION.U;
-});
+    return DEFAULT.ACTION[props.commit.status] || `[未知操作: ${props.commit.status}]`;
+})
+
 const message = computed(() => {
-    if (["A", "D", "M"].includes(props.info.status)) {
-        return `${action.value}了本页`;
-    } else if (["R", "C"].includes(props.info.status)) {
-        return (props.info.from)
-            ? `从${props.info.from.match(/[^/]+$/)[0]}${action.value}为本页`
-            : `将本页${action.value}为${props.info.to.match(/[^/]+$/)[0]}`
+    if (["A", "M", "D"].includes(props.commit.status)) {
+        return `${action.value}了本页`
+    } else if (props.commit.status === "R") {
+        return props.commit.from
+            ? `将 ${DEFAULT.BASENAME(props.commit.from)} 重命名为本页`
+            : `本页被重命名为 ${DEFAULT.BASENAME(props.commit.to)}`
+    } else if (props.commit.status === "C") {
+        return props.commit.from
+            ? `从 ${DEFAULT.BASENAME(props.commit.from)} 复制为本页`
+            : `本页复制为 ${DEFAULT.BASENAME(props.commit.to)}`
     };
-    return `未知操作了本页`;
+    return `${action.value}了本页`;
 });
 </script>
 
@@ -48,16 +54,16 @@ const message = computed(() => {
 <template>
     <component
         :is="props.repository ? 'a' : 'div'"
-        :href="props.repository ? `${props.repository}/commit/${props.info.hash}` : undefined"
+        :href="props.repository ? `${props.repository}/commit/${props.commit.hash}` : undefined"
         :target="props.repository ? '_blank' : undefined"
         :rel="props.repository ? 'noopener' : undefined"
         class="vpj-panel__history-item"
     >
         <div class="vpj-panel__history-item-message">
-            <strong>{{ props.info.author }}</strong> {{ message }}
+            <strong>{{ props.commit.author }}</strong> {{ message }}
         </div>
         <div class="vpj-panel__history-item-commit">
-            在提交 {{ props.info.message }} 中({{ props.info.hash }})
+            在提交 <code>{{ props.commit.hash }}</code> 中：{{ props.commit.message }}
         </div>
     </component>
 </template>
@@ -69,22 +75,30 @@ const message = computed(() => {
         border-radius: var(--vpj-border-radius-200);
         display: flex;
         flex-direction: column;
-        gap: .25rem;
-        padding: .5rem;
+        gap: 0.25rem;
+        padding: 0.5rem;
+        text-decoration: none;
     }
 
     .vpj-panel__history-item:hover,
     .vpj-panel__history-item:active {
-        background-color: var(--vpj-color-bg-400);
+        background-color: var(--vpj-color-bg-300);
     }
 
     .vpj-panel__history-item-message {
-        font-size: 1rem;
-        color: var(--vpj-color-text-400)
+        font-size: .875rem;
+        color: var(--vpj-color-text-400);
     }
 
     .vpj-panel__history-item-commit {
-        font-size: .75rem;
+        font-size: 0.75rem;
         color: var(--vpj-color-text-200);
+    }
+
+    .vpj-panel__history-item-commit > code {
+        background-color: var(--vpj-color-bg-500);
+        border-radius: var(--vpj-border-radius-100);
+        color: var(--vpj-color-text-400);
+        padding: .125rem .25rem .125rem .25rem;
     }
 </style>

--- a/docs/.vitepress/theme/components/VPJPanelHistoryItem.vue
+++ b/docs/.vitepress/theme/components/VPJPanelHistoryItem.vue
@@ -1,0 +1,90 @@
+<script setup>
+import { computed } from 'vue';
+
+const props = defineProps({
+    path: {
+        type: String,
+        required: true
+    },
+    url: {
+        type: String,
+        required: true
+    },
+    info: {
+        type: Object,
+        default: {}
+    },
+    repository: {
+        type: String
+    }
+});
+const DEFAULT = {
+    ACTION: {
+        A: "添加",
+        M: "修改",
+        D: "删除",
+        R: "重命名",
+        C: "复制",
+        U: "未知"
+    }
+}
+
+const action = computed(() => {
+    return DEFAULT.ACTION[props.info.status] || DEFAULT.ACTION.U;
+});
+const message = computed(() => {
+    if (["A", "D", "M"].includes(props.info.status)) {
+        return `${action.value}了本页`;
+    } else if (["R", "C"].includes(props.info.status)) {
+        return (props.info.from)
+            ? `从${props.info.from.match(/[^/]+$/)[0]}${action.value}为本页`
+            : `将本页${action.value}为${props.info.to.match(/[^/]+$/)[0]}`
+    };
+    return `未知操作了本页`;
+});
+</script>
+
+
+<template>
+    <component
+        :is="props.repository ? 'a' : 'div'"
+        :href="props.repository ? `${props.repository}/commit/${props.info.hash}` : undefined"
+        :target="props.repository ? '_blank' : undefined"
+        :rel="props.repository ? 'noopener' : undefined"
+        class="vpj-panel__history-item"
+    >
+        <div class="vpj-panel__history-item-message">
+            <strong>{{ props.info.author }}</strong> {{ message }}
+        </div>
+        <div class="vpj-panel__history-item-commit">
+            在提交 {{ props.info.message }} 中({{ props.info.hash }})
+        </div>
+    </component>
+</template>
+
+
+<style scoped>
+    .vpj-panel__history-item {
+        background-color: transparent;
+        border-radius: var(--vpj-border-radius-200);
+        display: flex;
+        flex-direction: column;
+        gap: .25rem;
+        padding: .5rem;
+    }
+
+    .vpj-panel__history-item:hover,
+    .vpj-panel__history-item:active {
+        background-color: var(--vpj-color-bg-400);
+    }
+
+    .vpj-panel__history-item-message {
+        font-size: 1rem;
+        color: var(--vpj-color-text-400)
+    }
+
+    .vpj-panel__history-item-commit {
+        font-size: .75rem;
+        color: var(--vpj-color-text-200);
+    }
+</style>

--- a/docs/.vitepress/theme/components/VPJPanelHistoryPage.vue
+++ b/docs/.vitepress/theme/components/VPJPanelHistoryPage.vue
@@ -1,0 +1,79 @@
+<script setup>
+import { ref, computed } from 'vue';
+import { useData, useRoute } from 'vitepress';
+
+import { data } from '../data/history.data';
+
+import VPJOverlayScrollArea from './VPJOverlayScrollArea.vue';
+import VPJPanelHistoryItem from './VPJPanelHistoryItem.vue';
+
+
+const DEFAULT = {
+    EMPTY: "没有历史提交记录",
+}
+
+const { theme } = useData();
+const route = useRoute();
+
+const fileData = computed(() => {
+    if (data[route.path]) return data[route.path];
+    return [];
+});
+const empty = computed(() => {
+    const message = theme.value.components?.panelTabHistory?.empty;
+    return (typeof message === 'string') ? message : DEFAULT.EMPTY;
+});
+</script>
+
+
+<template>
+    <VPJOverlayScrollArea
+        overflow="y"
+        class="vpj-panel__tab-outer"
+        :area-attrs="{ class: 'vpj-panel__tab-area' }"
+        :inner-attrs="{ class: 'vpj-panel__tab-inner' }"
+    >
+        <div
+            v-if="fileData.history.length === 0"
+            class="vpj-panel__fallback"
+        >
+            {{ empty }}
+        </div>
+        <div
+            v-else
+            class="vpj-panel__history"
+        >
+            <VPJPanelHistoryItem
+                v-for="commit in fileData.history"
+                :key="commit.hash"
+                :path="fileData.path"
+                :url="fileData.url"
+                :info="commit"
+            />
+        </div>
+    </VPJOverlayScrollArea>
+</template>
+
+
+<style scoped>
+    .vpj-panel__tab-outer {
+        background-color: var(--vpj-color-bg-100);
+        height: 100%;
+        width: 100%;
+    }
+
+    :deep(.vpj-panel__tab-inner) {
+        align-items: center;
+        display: flex;
+        flex-direction: column;
+        width: 100%
+    }
+
+    .vpj-panel__history {
+        display: flex;
+        flex-direction: column;
+        gap: .5rem;
+        width: 100%;
+        padding: .5rem;
+    }
+</style>

--- a/docs/.vitepress/theme/components/VPJPanelHistoryPage.vue
+++ b/docs/.vitepress/theme/components/VPJPanelHistoryPage.vue
@@ -1,8 +1,10 @@
 <script setup>
-import { ref, computed } from 'vue';
+import { computed } from 'vue';
 import { useData, useRoute } from 'vitepress';
 
 import { data } from '../data/history.data';
+
+import { formatDate } from '../utils/common';
 
 import VPJOverlayScrollArea from './VPJOverlayScrollArea.vue';
 import VPJPanelHistoryItem from './VPJPanelHistoryItem.vue';
@@ -10,18 +12,104 @@ import VPJPanelHistoryItem from './VPJPanelHistoryItem.vue';
 
 const DEFAULT = {
     EMPTY: "没有历史提交记录",
-}
+    INTERVALFORMAT: ":YYYY-:MM-:DD",
+    INTERVALKEY: ["year", "month", "week", "day", "hour", "minute", "second"]
+};
 
 const { theme } = useData();
 const route = useRoute();
 
 const fileData = computed(() => {
     if (data[route.path]) return data[route.path];
-    return [];
+    return { history: []};
+});
+
+// Fetch user config
+const repository = computed(() => {
+    const config = theme.value.components?.panelTabHistory?.repository;
+    return (typeof config === 'string') ? config : undefined;
+});
+const interval = computed(() => {
+    const config = theme.value.components?.panelTabHistory?.interval;
+    return (DEFAULT.INTERVALKEY.includes(config)) ? config : undefined;
+});
+const intervalFormat = computed(() => {
+    const config = theme.value.components?.panelTabHistory?.intervalFormat;
+
+    let format;
+    if (typeof config === 'function') {
+        format = config;
+    } else {
+        const pattern = (typeof config === 'string') ? config : DEFAULT.INTERVALFORMAT;
+        return (date) => formatDate(date, pattern);
+    };
+    return (date) => {
+        try {
+            const label = format(date);
+            return typeof label === 'string' ? label : undefined
+        } catch (e) {
+            console.error("[Juicy Theme] Failed to format history interval: " + e)
+            return undefined
+        };
+    };
+});
+const itemComponent = computed(() => {
+    const config = theme.value.components?.panelTabHistory?.component;
+    return (typeof config === 'string') ? config : VPJPanelHistoryItem;
 });
 const empty = computed(() => {
     const message = theme.value.components?.panelTabHistory?.empty;
     return (typeof message === 'string') ? message : DEFAULT.EMPTY;
+});
+
+
+// Group by interval
+const groupedHistory = computed(() => {
+    if (!interval.value) return fileData.value.history.map((commit) => ({
+        label: intervalFormat.value(new Date(commit.time)),
+        commits: [commit]
+    }));
+
+    const groups = {};
+    for (const commit of fileData.value.history) {
+        const d = new Date(commit.time);
+        let keyDate;
+        switch (interval.value) {
+            case "year":
+                keyDate = new Date(d.getFullYear(), 0);
+                break;
+            case "month":
+                keyDate = new Date(d.getFullYear(), d.getMonth());
+                break;
+            case "week":
+                d.setDate(d.getDate() - d.getDay())
+                keyDate = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+                break;
+            case "day":
+                keyDate = new Date(d.getFullYear(), d.getMonth(), d.getDate());
+                break;
+            case "hour":
+                keyDate = new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours());
+                break;
+            case "minute":
+                keyDate = new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours(), d.getMinutes());
+                break;
+            case "second":
+                keyDate = new Date(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours(), d.getMinutes(), d.getSeconds());
+                break;
+        };
+        const key = keyDate.toISOString();
+        if (!groups[key]) groups[key] = [];
+        groups[key].push(commit);
+    };
+
+    return Object.entries(groups)
+        .sort(([a], [b]) => new Date(b) - new Date(a))
+        .map(([key, commits]) => ({
+            key,
+            label: intervalFormat.value(new Date(key)),
+            commits
+        }));
 });
 </script>
 
@@ -43,13 +131,27 @@ const empty = computed(() => {
             v-else
             class="vpj-panel__history"
         >
-            <VPJPanelHistoryItem
-                v-for="commit in fileData.history"
-                :key="commit.hash"
-                :path="fileData.path"
-                :url="fileData.url"
-                :info="commit"
-            />
+            <template
+                v-for="{ key, label, commits } in groupedHistory"
+                :key="key"
+            >
+                <div v-if="label" class="vpj-panel__hitory-time-label">{{ label }}</div>
+                <ul class="vpj-panel__history-list">
+                    <li
+                        v-for="commit in commits"
+                        :key="commit.hash"
+                        class="vpj-panel__history-list-item"
+                    >
+                        <component
+                            :is="itemComponent"
+                            :path="fileData.path"
+                            :url="fileData.url"
+                            :repository="repository"
+                            :commit="commit"
+                        />
+                    </li>
+                </ul>
+            </template>
         </div>
     </VPJOverlayScrollArea>
 </template>
@@ -75,5 +177,28 @@ const empty = computed(() => {
         gap: .5rem;
         width: 100%;
         padding: .5rem;
+    }
+
+    /* Time Label */
+    .vpj-panel__hitory-time-label {
+        color: var(--vpj-color-text-400);
+        font-size: 1rem;
+        font-weight: var(--vpj-font-weight-600);
+        margin: .25rem 0;
+    }
+
+    /* History List */
+    .vpj-panel__history-list {
+        display: flex;
+        flex-direction: column;
+        gap: .5rem;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+    }
+
+    .vpj-panel__history-list-item {
+        list-style: none;
+        width: 100%;
     }
 </style>

--- a/docs/.vitepress/theme/components/VPJSidebar.vue
+++ b/docs/.vitepress/theme/components/VPJSidebar.vue
@@ -71,7 +71,7 @@ provide(VPJ_SIDEBAR_SYMBOL, {
             padding-bottom 0.2s ease-in-out,
             width 0.2s ease-in-out,
             transform 0.2s ease-in-out;
-        width: min(16.5rem, 50vw);
+        width: min(16.5rem, 35vw);
         z-index: 0;
     }
 
@@ -90,7 +90,7 @@ provide(VPJ_SIDEBAR_SYMBOL, {
     @media screen and (max-width: 768px) {
         /* Sidebar */
         .vpj-sidebar {
-            width: min(20rem, 60vw);
+            width: min(20rem, 50vw);
             position: fixed;
             left: 0;
             z-index: 101;

--- a/docs/.vitepress/theme/components/VPJTooltipBtn.vue
+++ b/docs/.vitepress/theme/components/VPJTooltipBtn.vue
@@ -17,21 +17,21 @@ const props = defineProps({
     },
     iconAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     text: {
         type: String
     },
     textAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     tooltip: {
         type: [String, undefined],
     },
     tooltipAttrs: {
         type: Object,
-        default: {}
+        default: () => ({})
     },
     tooltipPosition: {
         type: String,

--- a/docs/.vitepress/theme/components/VPJTooltipBtn.vue
+++ b/docs/.vitepress/theme/components/VPJTooltipBtn.vue
@@ -129,17 +129,17 @@ function updateTooltipPosition() {
     }
 }
 
+
+let observer = undefined;
 if (props.tooltip) {
     const stopTooltipWatcher = watch(tooltipVisible, (val) => {
         if (val) nextTick(updateTooltipPosition);
     });
-    const observer = new ResizeObserver(updateTooltipPosition);
 
     let currentBoundary = null;
     const stopObserverWatcher = watch(() => props.boundary, (val) => {
-        if (currentBoundary) {
-            observer.unobserve(currentBoundary);
-        }
+        if (!observer) return;
+        if (currentBoundary) observer.unobserve(currentBoundary);
         if (val) {
             const newBoundary = document.querySelector(val);
             if (newBoundary) {
@@ -147,13 +147,21 @@ if (props.tooltip) {
                 currentBoundary = newBoundary;
             }
         }
-    }, { immediate: true });
+    });
 
     onMounted(() => {
+        observer = new ResizeObserver(updateTooltipPosition);
         window.removeEventListener('resize', updateTooltipPosition);
         window.addEventListener('resize', updateTooltipPosition);
         observer.observe(button.value);
-    })
+        if (props.boundary) {
+        const newBoundary = document.querySelector(props.boundary)
+            if (newBoundary) {
+                observer.observe(newBoundary);
+                currentBoundary = newBoundary;
+            };
+        };
+    });
 
     onUnmounted(() => {
         window.removeEventListener('resize', updateTooltipPosition);

--- a/docs/.vitepress/theme/composables/useBlogData.ts
+++ b/docs/.vitepress/theme/composables/useBlogData.ts
@@ -3,6 +3,8 @@ import { cloneDeep } from "lodash-es";
 
 // @ts-ignore
 import { data } from "../data/blog.data";
+// @ts-ignore
+import { data as history } from "../data/history.data";
 
 import { VPJ_BLOG_DATA_SYMBOL } from "../utils/symbols";
 import { mergeSimpleData } from "../utils/mergeData";
@@ -47,12 +49,20 @@ interface RawBlogPageData {
     prev:
         | { text?: string; link?: string }
         | { text: false; link: false };
+    lastUpdated?:
+        | Date
+        | false;
+    createdAt?:
+        | Date
+        | false;
 }
 
 interface StoreBlogPageData extends RawBlogPageData {
     id: string;
     next: { text?: string; link?: string };
     prev: { text?: string; link?: string };
+    lastUpdated?: Date;
+    createdAt?: Date;
 }
 
 interface BlogStoreContext {
@@ -82,6 +92,8 @@ export class BlogPageData {
                 text: (raw.prev.text === false) ? undefined : raw.prev.text,
                 link: (raw.prev.link === false) ? undefined : raw.prev.link,
             },
+            lastUpdated: (raw.lastUpdated === false) ? undefined : raw.lastUpdated,
+            createdAt: (raw.createdAt === false) ? undefined : raw.createdAt,
         };
         this.#storeContext = storeContext;
 

--- a/docs/.vitepress/theme/composables/useDocData.ts
+++ b/docs/.vitepress/theme/composables/useDocData.ts
@@ -3,6 +3,8 @@ import { cloneDeep } from "lodash-es";
 
 // @ts-ignore
 import { data } from "../data/doc.data";
+// @ts-ignore
+import { data as history } from "../data/history.data";
 
 import { VPJ_DOC_DATA_SYMBOL } from "../utils/symbols";
 import { any2Number, processDocOrder } from "../utils/common";
@@ -49,6 +51,12 @@ interface RawDocPageData {
     prev:
         | { text?: string; link?: string }
         | { text: false; link: false };
+    lastUpdated?:
+        | Date
+        | false;
+    createdAt?:
+        | Date
+        | false;
     inherit?: boolean;
     virtual?: boolean;
 }
@@ -58,6 +66,8 @@ interface StoreDocPageData extends RawDocPageData {
     id: string;
     next: { text?: string; link?: string };
     prev: { text?: string; link?: string };
+    lastUpdated?: Date;
+    createdAt?: Date;
     inherit: boolean;
     virtual: boolean;
 }
@@ -194,6 +204,8 @@ export class DocPageData {
             },
             inherit: (raw.inherit === true) ? true : false,
             virtual: (raw.virtual === true) ? true : false,
+            lastUpdated: (raw.lastUpdated === false) ? undefined : raw.lastUpdated,
+            createdAt: (raw.createdAt === false) ? undefined : raw.createdAt,
         };
         this.#storeContext = storeContext;
 

--- a/docs/.vitepress/theme/composables/useDocData.ts
+++ b/docs/.vitepress/theme/composables/useDocData.ts
@@ -3,7 +3,6 @@ import { cloneDeep } from "lodash-es";
 
 // @ts-ignore
 import { data } from "../data/doc.data";
-// @ts-ignore
 import { data as history } from "../data/history.data";
 
 import { VPJ_DOC_DATA_SYMBOL } from "../utils/symbols";
@@ -27,13 +26,15 @@ interface DocData {
     resources: Ref<Record<string, ResourceInput> | undefined>;
     next: Ref<{ text?: string; link?: string } | undefined>;
     prev: Ref<{ text?: string; link?: string } | undefined>;
+    lastUpdated: Ref<Date | undefined>;
+    createdAt: Ref<Date | undefined>;
     ctx: Ref<PageContext | undefined>;
     filter: (callbackFn: (data: DocPageData) => boolean) => DocPageData[];
     spaceConfig: Ref<SpaceMetaData>;
     layoutConfig: Ref<VPJDocLayoutConfig>;
 }
 
-interface RawDocPageData {
+interface BaseDocPageData {
     title?: string;
     space?: string;
     order: number[];
@@ -51,17 +52,20 @@ interface RawDocPageData {
     prev:
         | { text?: string; link?: string }
         | { text: false; link: false };
-    lastUpdated?:
-        | Date
-        | false;
-    createdAt?:
-        | Date
-        | false;
     inherit?: boolean;
     virtual?: boolean;
 }
 
-interface StoreDocPageData extends RawDocPageData {
+interface RawDocPageData extends BaseDocPageData {
+    lastUpdated?:
+        | number
+        | false;
+    createdAt?:
+        | number
+        | false;
+}
+
+interface StoreDocPageData extends BaseDocPageData {
     resources: Record<string, ResourceData>;
     id: string;
     next: { text?: string; link?: string };
@@ -204,8 +208,8 @@ export class DocPageData {
             },
             inherit: (raw.inherit === true) ? true : false,
             virtual: (raw.virtual === true) ? true : false,
-            lastUpdated: (raw.lastUpdated === false) ? undefined : raw.lastUpdated,
-            createdAt: (raw.createdAt === false) ? undefined : raw.createdAt,
+            lastUpdated: (typeof raw.lastUpdated === 'number') ? new Date(raw.lastUpdated) : undefined,
+            createdAt: (typeof raw.createdAt === 'number') ? new Date(raw.createdAt) : undefined,
         };
         this.#storeContext = storeContext;
 
@@ -228,6 +232,8 @@ export class DocPageData {
     get resources(): Record<string, ResourceData> { return this.#store.resources; }
     get next() { return this.#store.next; }
     get prev() { return this.#store.prev; }
+    get lastUpdated(): Date | undefined { return this.#store.lastUpdated; }
+    get createdAt(): Date | undefined { return this.#store.createdAt; }
     get treeTitle(): string {
         if (typeof this.#store.treeTitle === 'string') {
             return this.#store.treeTitle;
@@ -546,6 +552,24 @@ export class DocPageData {
         });
     };
 
+    static bindHistory(dataBase: RawDocPageData[]) {
+        if (!history || Object.keys(history).length === 0) return;
+
+        dataBase.forEach((curr) => {
+            if (!curr.url) return;
+
+            const log = history[curr.url];
+            if (Array.isArray(log?.history) && log.history.length > 0) {
+                curr.lastUpdated = (curr.lastUpdated === undefined)
+                    ? log.history[0].time
+                    : curr.lastUpdated;
+                curr.createdAt = (curr.createdAt === undefined)
+                    ? log.history[log.history.length - 1].time
+                    : curr.createdAt;
+            };
+        });
+    };
+
     static sortDataBase(dataBase: RawDocPageData[]) {
         return dataBase
             .sort((a: RawDocPageData, b: RawDocPageData) => {
@@ -580,6 +604,9 @@ export class DocPageData {
         if (typeof docConfig === 'object' && docConfig !== null) {
             DocPageData.applySpaceConfig(copy, docConfig);
         };
+
+        // Bind history
+        DocPageData.bindHistory(copy);
 
         // Sort nodes by space/order
         return DocPageData.sortDataBase(copy);
@@ -697,6 +724,22 @@ export function initVPJDocData(route: Route, siteData: Ref<SiteData>): DocData {
         return undefined;
     });
 
+    // Calculate lastUpdated
+    const lastUpdated = computed(() => {
+        if (frontmatter.value.layout === "doc") {
+            return currentData.value?.lastUpdated || undefined;
+        };
+        return undefined;
+    });
+
+    // Calculate createdAt
+    const createdAt = computed(() => {
+        if (frontmatter.value.layout === "doc") {
+            return currentData.value?.createdAt || undefined;
+        };
+        return undefined;
+    });
+
     // Calculate the context
     const ctx: Ref<PageContext | undefined> = computed(() => {
         if (frontmatter.value.layout === "doc") {
@@ -727,6 +770,8 @@ export function initVPJDocData(route: Route, siteData: Ref<SiteData>): DocData {
         resources,
         prev,
         next,
+        lastUpdated,
+        createdAt,
         ctx,
         filter,
         spaceConfig,

--- a/docs/.vitepress/theme/composables/useVPJLayout.ts
+++ b/docs/.vitepress/theme/composables/useVPJLayout.ts
@@ -1,5 +1,5 @@
-import { PageData, useData } from 'vitepress';
-import { ref, computed } from 'vue';
+import { useData } from 'vitepress';
+import { ref, computed, readonly } from 'vue';
 import { defineStore } from 'pinia';
 
 import { isMobile, isTablet } from '../utils/deviceTypes'
@@ -21,7 +21,7 @@ import { useBlogData } from './useBlogData';
 import { useDocData } from './useDocData';
 
 import type { Ref, ComputedRef } from 'vue';
-import type { SiteData } from 'vitepress';
+import type { SiteData, PageData } from 'vitepress';
 import type { ThemeConfig } from '../types';
 import type { CoverCssConfigData, DeviceSpecificData } from '../types/common';
 import type { VPJBlogLayoutConfig } from '../types/layoutBlog';
@@ -142,6 +142,9 @@ const DEFAULT = {
     },
 };
 
+const PANEL_TAB = ["history"] as const;
+type PANEL_TAB_TYPE = typeof PANEL_TAB[number];
+
 function getDeviceSpecificData(data: DeviceSpecificData) {
     if (isMobile.value) return data.mobile;
     if (isTablet.value) return data.tablet;
@@ -205,6 +208,26 @@ export const useVPJLayout = defineStore("vpj-layout", () => {
     function asideToggle(): void { asideCollapsed.value = !asideCollapsed.value; };
     function asideClose(): void { asideCollapsed.value = true; };
     function asideOpen(): void { asideCollapsed.value = false; };
+
+    const panelCollapsed: Ref<boolean> = ref(true);
+    const panelTab: Ref<PANEL_TAB_TYPE | undefined> = ref(undefined);
+    function panelToggle(tab: PANEL_TAB_TYPE): void {
+        if (PANEL_TAB.includes(tab) && panelCollapsed.value === true) {
+            panelOpen(tab);
+        } else {
+            panelClose();
+        };
+    };
+    function panelClose(): void {
+        panelTab.value = undefined;
+        panelCollapsed.value = true;
+    }
+    function panelOpen(tab: PANEL_TAB_TYPE): void {
+        if (PANEL_TAB.includes(tab)) {
+            panelTab.value = tab;
+            panelCollapsed.value = false;
+        };
+    }
 
     // Head config
     const headConfig = computed(() => {
@@ -570,10 +593,16 @@ export const useVPJLayout = defineStore("vpj-layout", () => {
     });
 
     return {
-        asideCollapsed,
+        asideCollapsed: readonly(asideCollapsed),
         asideClose,
         asideOpen,
         asideToggle,
+
+        panelCollapsed: readonly(panelCollapsed),
+        panelTab: readonly(panelTab),
+        panelClose,
+        panelOpen,
+        panelToggle,
 
         headConfig,
         contentConfig,

--- a/docs/.vitepress/theme/composables/useVPJLayout.ts
+++ b/docs/.vitepress/theme/composables/useVPJLayout.ts
@@ -15,6 +15,7 @@ import {
     mergeToolbarButtonData,
     mergeFooterData,
     mergeEditLinkData,
+    mergeTimeLabelData,
 } from '../utils/mergeData';
 
 import { useBlogData } from './useBlogData';
@@ -96,6 +97,7 @@ const DEFAULT = {
         EDITLINK: undefined,
         NEXT: "Next",
         PREV: "Previous",
+        TIMELABEL: undefined,
     },
     "DOC":{
         TITLETEMPLATE: true,
@@ -139,6 +141,7 @@ const DEFAULT = {
         EDITLINK: undefined,
         NEXT: "下一页",
         PREV: "上一页",
+        TIMELABEL: undefined,
     },
 };
 
@@ -158,8 +161,20 @@ export const useVPJLayout = defineStore("vpj-layout", () => {
         theme: Ref<ThemeConfig, ThemeConfig>,
         site: Ref<SiteData<ThemeConfig>, SiteData<ThemeConfig>>
     } = useData();
-    const { layoutConfig: docLayoutConfig, spaceConfig: docSpecificConfig, ctx: docCtx } = useDocData();
-    const { layoutConfig: blogLayoutConfig, seriesConfig: blogSpecificConfig, ctx: blogCtx } = useBlogData();
+    const {
+        layoutConfig: docLayoutConfig,
+        spaceConfig: docSpecificConfig,
+        ctx: docCtx,
+        lastUpdated: docLastUpdated,
+        createdAt: docCreatedAt
+    } = useDocData();
+    const {
+        layoutConfig: blogLayoutConfig,
+        seriesConfig: blogSpecificConfig,
+        ctx: blogCtx,
+        lastUpdated: blogLastUpdated,
+        createdAt: blogCreatedAt
+    } = useBlogData();
     const pageLayoutConfig = computed(() => {
         return (typeof theme.value.layouts?.page === "object" && theme.value.layouts.page)
             ? theme.value.layouts.page
@@ -196,6 +211,16 @@ export const useVPJLayout = defineStore("vpj-layout", () => {
     const ctx = computed(() => {
         if (layout.value === "blog") return blogCtx.value;
         if (layout.value === "doc") return docCtx.value;
+        return undefined;
+    });
+    const lastUpdated = computed(() => {
+        if (layout.value === "blog") return blogLastUpdated.value;
+        if (layout.value === "doc") return docLastUpdated.value;
+        return undefined;
+    });
+    const createdAt = computed(() => {
+        if (layout.value === "blog") return blogCreatedAt.value;
+        if (layout.value === "doc") return docCreatedAt.value;
         return undefined;
     });
 
@@ -492,6 +517,17 @@ export const useVPJLayout = defineStore("vpj-layout", () => {
                 defaultConfig.value.EDITLINK
             );
 
+            // Calculate time label
+            const timeLabel = mergeTimeLabelData(
+                lastUpdated.value,
+                createdAt.value,
+                frontmatter.value.timeLabel,
+                specificConfig.value.timeLabel,
+                (layoutConfig.value as VPJDocLayoutConfig | VPJBlogLayoutConfig).timeLabel,
+                theme.value.timeLabel,
+                defaultConfig.value.TIMELABEL
+            );
+
             // Calculate next label
             const nextLabel = mergeSimpleData<string | false, false>(
                 (v) => typeof v === 'string' || v === false,
@@ -516,6 +552,7 @@ export const useVPJLayout = defineStore("vpj-layout", () => {
 
             return {
                 editLink,
+                timeLabel,
                 nextLabel,
                 prevLabel
             };

--- a/docs/.vitepress/theme/composables/useVPJLayout.ts
+++ b/docs/.vitepress/theme/composables/useVPJLayout.ts
@@ -43,7 +43,7 @@ const DEFAULT = {
         TITLETEMPLATE: true,
         FAVICON: undefined,
         DESCRPTION: undefined,
-        CONTENTMARGINBOTTOM: "1.5rem",
+        CONTENTMARGINBOTTOM: "2.5rem",
         CONTENTMARGINTOP: "1.5rem",
         CONTENTMAXWIDTH: "61.25rem",
         CONTENTPADDING: {
@@ -84,7 +84,7 @@ const DEFAULT = {
             objectFit: "cover",
             objectPosition: "center center"
         },
-        CONTENTMARGINBOTTOM: "1.5rem",
+        CONTENTMARGINBOTTOM: "2.5rem",
         CONTENTMARGINTOP: "1.5rem",
         CONTENTMAXWIDTH: "760px",
         CONTENTPADDING: {
@@ -127,7 +127,7 @@ const DEFAULT = {
             objectFit: "cover",
             objectPosition: "center center"
         },
-        CONTENTMARGINBOTTOM: "1.5rem",
+        CONTENTMARGINBOTTOM: "2.5rem",
         CONTENTMARGINTOP: "1.5rem",
         CONTENTMAXWIDTH: "820px",
         CONTENTPADDING: {

--- a/docs/.vitepress/theme/data/blog.data.ts
+++ b/docs/.vitepress/theme/data/blog.data.ts
@@ -41,15 +41,16 @@ export default createContentLoader("**/*.md", {
                 let prev = resolveNavigationInput(raw.frontmatter.prev);
 
                 // Process lastUpdated&createdAt
-                const lastUpdated = (raw.frontmatter.lastUpdated instanceof Date || raw.frontmatter.lastUpdated === false)
+                const lastUpdated = (raw.frontmatter.lastUpdated === false)
                     ? raw.frontmatter.lastUpdated
-                    : undefined;
-                const createdAt = (raw.frontmatter.createdAt instanceof Date || raw.frontmatter.createdAt === false)
+                    : (raw.frontmatter.lastUpdated instanceof Date && !isNaN(raw.frontmatter.lastUpdated.getTime()))
+                        ? raw.frontmatter.lastUpdated.getTime()
+                        : undefined;
+                const createdAt = (raw.frontmatter.createdAt === false)
                     ? raw.frontmatter.createdAt
-                    : undefined;
-                const timeLabel = (typeof raw.frontmatter.timeLabel === 'string' || raw.frontmatter.timeLabel === false)
-                    ? raw.frontmatter.timeLabel
-                    : undefined;
+                    : (raw.frontmatter.createdAt instanceof Date && !isNaN(raw.frontmatter.createdAt.getTime()))
+                        ? raw.frontmatter.createdAt.getTime()
+                        : undefined;
                 
                 return {
                     ...raw,
@@ -73,7 +74,6 @@ export default createContentLoader("**/*.md", {
                     prev,
                     lastUpdated,
                     createdAt,
-                    timeLabel,
                 };
             });
     },

--- a/docs/.vitepress/theme/data/blog.data.ts
+++ b/docs/.vitepress/theme/data/blog.data.ts
@@ -39,6 +39,17 @@ export default createContentLoader("**/*.md", {
                 // Process next&prev
                 let next = resolveNavigationInput(raw.frontmatter.next);
                 let prev = resolveNavigationInput(raw.frontmatter.prev);
+
+                // Process lastUpdated&createdAt
+                const lastUpdated = (raw.frontmatter.lastUpdated instanceof Date || raw.frontmatter.lastUpdated === false)
+                    ? raw.frontmatter.lastUpdated
+                    : undefined;
+                const createdAt = (raw.frontmatter.createdAt instanceof Date || raw.frontmatter.createdAt === false)
+                    ? raw.frontmatter.createdAt
+                    : undefined;
+                const timeLabel = (typeof raw.frontmatter.timeLabel === 'string' || raw.frontmatter.timeLabel === false)
+                    ? raw.frontmatter.timeLabel
+                    : undefined;
                 
                 return {
                     ...raw,
@@ -60,6 +71,9 @@ export default createContentLoader("**/*.md", {
                         : undefined,
                     next,
                     prev,
+                    lastUpdated,
+                    createdAt,
+                    timeLabel,
                 };
             });
     },

--- a/docs/.vitepress/theme/data/doc.data.ts
+++ b/docs/.vitepress/theme/data/doc.data.ts
@@ -41,6 +41,17 @@ export default createContentLoader("**/*.md", {
                 // Process next&prev
                 let next = resolveNavigationInput(raw.frontmatter.next);
                 let prev = resolveNavigationInput(raw.frontmatter.prev);
+
+                // Process lastUpdated&createdAt
+                const lastUpdated = (raw.frontmatter.lastUpdated instanceof Date || raw.frontmatter.lastUpdated === false)
+                    ? raw.frontmatter.lastUpdated
+                    : undefined;
+                const createdAt = (raw.frontmatter.createdAt instanceof Date || raw.frontmatter.createdAt === false)
+                    ? raw.frontmatter.createdAt
+                    : undefined;
+                const timeLabel = (typeof raw.frontmatter.timeLabel === 'string' || raw.frontmatter.timeLabel === false)
+                    ? raw.frontmatter.timeLabel
+                    : undefined;
                 
                 // Filter resources
                 const rawResources: Record<string, ResourceInput> = 
@@ -110,6 +121,9 @@ export default createContentLoader("**/*.md", {
                         : !!raw.frontmatter.allowVirtualParents,
                     next,
                     prev,
+                    lastUpdated,
+                    createdAt,
+                    timeLabel,
                 }
             })
     },

--- a/docs/.vitepress/theme/data/doc.data.ts
+++ b/docs/.vitepress/theme/data/doc.data.ts
@@ -43,15 +43,16 @@ export default createContentLoader("**/*.md", {
                 let prev = resolveNavigationInput(raw.frontmatter.prev);
 
                 // Process lastUpdated&createdAt
-                const lastUpdated = (raw.frontmatter.lastUpdated instanceof Date || raw.frontmatter.lastUpdated === false)
+                const lastUpdated = (raw.frontmatter.lastUpdated === false)
                     ? raw.frontmatter.lastUpdated
-                    : undefined;
-                const createdAt = (raw.frontmatter.createdAt instanceof Date || raw.frontmatter.createdAt === false)
+                    : (raw.frontmatter.lastUpdated instanceof Date && !isNaN(raw.frontmatter.lastUpdated.getTime()))
+                        ? raw.frontmatter.lastUpdated.getTime()
+                        : undefined;
+                const createdAt = (raw.frontmatter.createdAt === false)
                     ? raw.frontmatter.createdAt
-                    : undefined;
-                const timeLabel = (typeof raw.frontmatter.timeLabel === 'string' || raw.frontmatter.timeLabel === false)
-                    ? raw.frontmatter.timeLabel
-                    : undefined;
+                    : (raw.frontmatter.createdAt instanceof Date && !isNaN(raw.frontmatter.createdAt.getTime()))
+                        ? raw.frontmatter.createdAt.getTime()
+                        : undefined;
                 
                 // Filter resources
                 const rawResources: Record<string, ResourceInput> = 
@@ -123,7 +124,6 @@ export default createContentLoader("**/*.md", {
                     prev,
                     lastUpdated,
                     createdAt,
-                    timeLabel,
                 }
             })
     },

--- a/docs/.vitepress/theme/data/history.data.ts
+++ b/docs/.vitepress/theme/data/history.data.ts
@@ -142,11 +142,12 @@ export default {
         };
 
         watchFiles.forEach((file) => {
-            const url =
+            const url = encodeURI(
                 '/' +
                 normalizePath(path.relative(config.srcDir, file))
                     .replace(/(^|\/)index\.md$/, '$1')
-                    .replace(/\.md$/, config.cleanUrls ? '' : '.html');
+                    .replace(/\.md$/, config.cleanUrls ? '' : '.html')
+            );
 
             const history = fileCommitMap.get(file) ?? [];
             result[url] = { path: file, url, history };

--- a/docs/.vitepress/theme/data/history.data.ts
+++ b/docs/.vitepress/theme/data/history.data.ts
@@ -2,49 +2,86 @@ import { normalizePath } from 'vite'
 import path from 'node:path'
 import { execFileSync } from 'node:child_process'
 
-import type { SiteConfig } from 'vitepress'
+import type { SiteConfig } from 'vitepress';
+
+
+interface CommitInfo {
+    time: Date,
+    hash: string,
+    author: string,
+    message: string,
+    status: string
+}
 
 export default {
-  watch: ['**/*.md'],
+    watch: ['**/*.md'],
 
-  load(watchFiles: string[]) {
-    const config: SiteConfig = (global as any).VITEPRESS_CONFIG
-    if (!config) {
-      throw new Error(
-        'content loader invoked without an active vitepress process, or before vitepress config is resolved.'
-      )
+    load(watchFiles: string[]) {
+        const config: SiteConfig = (global as any).VITEPRESS_CONFIG
+        if (!config) {
+            throw new Error("content loader invoked without an active vitepress process, or before vitepress config is resolved.")
+        };
+
+        if (!config.lastUpdated) return [];
+
+        let logOutput = "";
+        try {
+            logOutput = execFileSync(
+                "git",
+                ["log", "--name-status", "-z", "--format=%n%x00%x00%x00%ct%x00%x00%h%x00%x00%an%x00%x00%s%x00%x00%n", "--", "*.md"],
+                { encoding: "utf-8" }
+            );
+        } catch (e) {
+            if (e.code === "ENOENT") {
+                console.warn("[Juicy Theme] Error: Git is not installed or not available in PATH. Please install Git to use this feature.");
+                return [];
+            }
+            console.error("[Juicy Theme] Error: Data loader failed to fetch Git commit history. Throw error:", e);
+            return [];
+        };
+
+        const rawCommit = logOutput.split("\x00\x00\x00");
+        rawCommit.shift();
+
+        const commits = rawCommit.map((raw) => {
+            const parts = raw.split("\x00\x00");
+            const time = new Date(Number(parts[0]) * 1000);
+            const hash = parts[1];
+            const author = parts[2];
+            const message = parts.slice(3, -1).join("\x00\x00");
+            const filesRaw = parts[parts.length - 1].trim().split("\x00").filter(Boolean);
+            const files: { status: string, path: string }[] = [];
+            for (let i=0; i<filesRaw.length; i+=2) {
+                const status = filesRaw[i].trim();
+                const path = filesRaw[i+1];
+                files.push({ status, path });
+            }
+            return { time, hash, author, message, files };
+        });
+
+        const fileCommitMap = new Map<string, CommitInfo[]>();
+        for (const commit of commits) {
+            for (const f of commit.files) {
+                if (!fileCommitMap.has(f.path)) fileCommitMap.set(f.path, []);
+                fileCommitMap.get(f.path)!.push({
+                    time: commit.time,
+                    hash: commit.hash,
+                    author: commit.author,
+                    message: commit.message,
+                    status: f.status
+                });
+            };
+        };
+
+        return watchFiles.map((file) => {
+            const url =
+                '/' +
+                normalizePath(path.relative(config.srcDir, file))
+                    .replace(/(^|\/)index\.md$/, '$1')
+                    .replace(/\.md$/, config.cleanUrls ? '' : '.html');
+
+            const history = fileCommitMap.get(file) ?? [];
+            return { path: file, url, history };
+        });
     }
-
-    return watchFiles.map((file) => {
-      // 生成 URL
-      const url =
-        '/' +
-        normalizePath(path.relative(config.srcDir, file))
-          .replace(/(^|\/)index\.md$/, '$1')
-          .replace(/\.md$/, config.cleanUrls ? '' : '.html')
-
-      // 获取 Git 全部更新时间戳（毫秒）
-      let history: number[] | undefined
-      try {
-        const timestamps = execFileSync(
-          'git',
-          ['log', '--format=%ct', '--', file], // 所有提交时间
-          { encoding: 'utf8' }
-        )
-          .trim()
-          .split('\n')
-          .filter(Boolean)
-          .map((ts) => Number(ts) * 1000)
-
-        history = timestamps.length > 0 ? timestamps : undefined
-      } catch {
-        history = []
-      }
-
-      return {
-        url,
-        history
-      }
-    })
-  }
-}
+};

--- a/docs/.vitepress/theme/data/history.data.ts
+++ b/docs/.vitepress/theme/data/history.data.ts
@@ -1,0 +1,50 @@
+import { normalizePath } from 'vite'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+import type { SiteConfig } from 'vitepress'
+
+export default {
+  watch: ['**/*.md'],
+
+  load(watchFiles: string[]) {
+    const config: SiteConfig = (global as any).VITEPRESS_CONFIG
+    if (!config) {
+      throw new Error(
+        'content loader invoked without an active vitepress process, or before vitepress config is resolved.'
+      )
+    }
+
+    return watchFiles.map((file) => {
+      // 生成 URL
+      const url =
+        '/' +
+        normalizePath(path.relative(config.srcDir, file))
+          .replace(/(^|\/)index\.md$/, '$1')
+          .replace(/\.md$/, config.cleanUrls ? '' : '.html')
+
+      // 获取 Git 全部更新时间戳（毫秒）
+      let history: number[] | undefined
+      try {
+        const timestamps = execFileSync(
+          'git',
+          ['log', '--format=%ct', '--', file], // 所有提交时间
+          { encoding: 'utf8' }
+        )
+          .trim()
+          .split('\n')
+          .filter(Boolean)
+          .map((ts) => Number(ts) * 1000)
+
+        history = timestamps.length > 0 ? timestamps : undefined
+      } catch {
+        history = []
+      }
+
+      return {
+        url,
+        history
+      }
+    })
+  }
+}

--- a/docs/.vitepress/theme/layouts/VPJLayoutBlog.vue
+++ b/docs/.vitepress/theme/layouts/VPJLayoutBlog.vue
@@ -30,7 +30,7 @@ const {
     coverConfig,
     asideConfig
 } = storeToRefs(store);
-const { cover, prev, next } = useBlogData();
+const { data, cover, prev, next, lastUpdated, createdAt } = useBlogData();
 
 useHead(headConfig);
 

--- a/docs/.vitepress/theme/layouts/VPJLayoutPage.vue
+++ b/docs/.vitepress/theme/layouts/VPJLayoutPage.vue
@@ -10,6 +10,8 @@ import { VPJ_PAGE_LAYOUT_SYMBOL } from '../utils/symbols';
 import VPJOverlayScrollArea from '../components/VPJOverlayScrollArea.vue';
 import VPJFooter from '../components/VPJFooter.vue';
 
+import { data } from '../data/history.data'
+
 
 const store = useVPJLayout();
 const {
@@ -54,6 +56,7 @@ provide(VPJ_PAGE_LAYOUT_SYMBOL, {
             </div>
             <slot>
                 <div class="vpj-layout-page__content">
+                    {{ data }}
                     <Content class=" vpj-markdown"/>
                     <VPJFooter/>
                 </div>                

--- a/docs/.vitepress/theme/layouts/VPJLayoutPage.vue
+++ b/docs/.vitepress/theme/layouts/VPJLayoutPage.vue
@@ -56,7 +56,6 @@ provide(VPJ_PAGE_LAYOUT_SYMBOL, {
             </div>
             <slot>
                 <div class="vpj-layout-page__content">
-                    {{ data }}
                     <Content class=" vpj-markdown"/>
                     <VPJFooter/>
                 </div>                

--- a/docs/.vitepress/theme/layouts/VPJLayoutPage.vue
+++ b/docs/.vitepress/theme/layouts/VPJLayoutPage.vue
@@ -10,8 +10,6 @@ import { VPJ_PAGE_LAYOUT_SYMBOL } from '../utils/symbols';
 import VPJOverlayScrollArea from '../components/VPJOverlayScrollArea.vue';
 import VPJFooter from '../components/VPJFooter.vue';
 
-import { data } from '../data/history.data'
-
 
 const store = useVPJLayout();
 const {

--- a/docs/.vitepress/theme/types/blog.ts
+++ b/docs/.vitepress/theme/types/blog.ts
@@ -1625,4 +1625,8 @@ export interface SeriesMetaData {
      * @see {@link VPJBlogLayoutConfig.autoNextPrev}
      */
     autoNextPrev?: boolean;
+
+    timeLabel?:
+        | string
+        | ((lastUpdated: Date | undefined, createdAt: Date | undefined) => string | undefined);
 }

--- a/docs/.vitepress/theme/types/component.ts
+++ b/docs/.vitepress/theme/types/component.ts
@@ -499,7 +499,7 @@ export type ComponentFallbackConfig = {
 
     panelTabHistory?: {
         interval?: "year" | "month" | "week" | "day" | "hour" | "minute" | "second";
-        intervalFormat?: (date: Date) => string;
+        intervalFormat?: string | ((date: Date) => string);
         repository?: string;
         component?: string;
         empty?: string;

--- a/docs/.vitepress/theme/types/component.ts
+++ b/docs/.vitepress/theme/types/component.ts
@@ -496,4 +496,12 @@ export type ComponentFallbackConfig = {
          */
         noSpace?: string;
     };
+
+    panelTabHistory?: {
+        interval?: "year" | "month" | "week" | "day" | "hour" | "minute" | "second";
+        intervalFormat?: (date: Date) => string;
+        repository?: string;
+        component?: string;
+        empty?: string;
+    }
 };

--- a/docs/.vitepress/theme/types/doc.ts
+++ b/docs/.vitepress/theme/types/doc.ts
@@ -1637,4 +1637,8 @@ export interface SpaceMetaData {
      * @see {@link VPJDocLayoutConfig.autoNextPrev} 布局层级自动上下页开关
      */
     autoNextPrev?: boolean;
+
+    timeLabel?:
+        | string
+        | ((lastUpdated: Date | undefined, createdAt: Date | undefined) => string | undefined);
 }

--- a/docs/.vitepress/theme/types/index.ts
+++ b/docs/.vitepress/theme/types/index.ts
@@ -391,4 +391,9 @@ export interface ThemeConfig {
      * ```
      */
     autoNextPrev?: boolean;
+
+
+    timeLabel?:
+        | string
+        | ((lastUpdated: Date | undefined, createdAt: Date | undefined) => string | undefined);
 }

--- a/docs/.vitepress/theme/types/layoutBlog.ts
+++ b/docs/.vitepress/theme/types/layoutBlog.ts
@@ -1285,4 +1285,8 @@ export interface VPJBlogLayoutConfig {
      * ```
      */
     autoNextPrev?: boolean;
+
+    timeLabel?:
+        | string
+        | ((lastUpdated: Date | undefined, createdAt: Date | undefined) => string | undefined);
 }

--- a/docs/.vitepress/theme/types/layoutDoc.ts
+++ b/docs/.vitepress/theme/types/layoutDoc.ts
@@ -1267,4 +1267,8 @@ export interface VPJDocLayoutConfig {
      * ```
      */
     autoNextPrev?: boolean;
+
+    timeLabel?:
+        | string
+        | ((lastUpdated: Date | undefined, createdAt: Date | undefined) => string | undefined);
 }

--- a/docs/.vitepress/theme/utils/common.ts
+++ b/docs/.vitepress/theme/utils/common.ts
@@ -38,3 +38,23 @@ export function resolveNavigationInput(input: any): { text?: string; link?: stri
     };
     return {};
 }
+
+
+function formatDate(date: Date, pattern: string): string {
+    const pad = (n: number) => n < 10 ? "0" + n : "" + n;
+    const replacements: Record<string, string> = {
+        ":YYYY": "" + date.getFullYear(),
+        ":YY": ("" + date.getFullYear()).slice(-2),
+        ":MM": pad(date.getMonth()+1),
+        ":M": "" + (date.getMonth()+1),
+        ":DD": pad(date.getDate()),
+        ":D": "" + date.getDate(),
+        ":hh": pad(date.getHours()),
+        ":h": "" + date.getHours(),
+        ":mm": pad(date.getMinutes()),
+        ":m": "" + date.getMinutes(),
+        ":ss": pad(date.getSeconds()),
+        ":s": "" + date.getSeconds()
+    };
+    return pattern.replace(/:YYYY|:YY|:MM|:M|:DD|:D|:hh|:h|:mm|:m|:ss|:s/g, match => replacements[match]);
+}

--- a/docs/.vitepress/theme/utils/common.ts
+++ b/docs/.vitepress/theme/utils/common.ts
@@ -41,43 +41,43 @@ export function resolveNavigationInput(input: any): { text?: string; link?: stri
 
 
 export function formatTimeLabel(
-    lastUpdated: Date | undefined,
-    createdAt: Date | undefined,
-    pattern: string
+  lastUpdated: Date | undefined,
+  createdAt: Date | undefined,
+  pattern: string
 ): string | undefined {
-    if (!lastUpdated && !createdAt) return undefined;
-    const pad = (n: number) => (n < 10 ? "0" + n : "" + n);
+  if (!lastUpdated && !createdAt) return undefined;
 
-    const map: Record<string, string> = {
-        lYYYY: lastUpdated ? "" + lastUpdated.getFullYear() : "",
-        lYY: lastUpdated ? ("" + lastUpdated.getFullYear()).slice(-2) : "",
-        lMM: lastUpdated ? pad(lastUpdated.getMonth() + 1) : "",
-        lM: lastUpdated ? "" + (lastUpdated.getMonth() + 1) : "",
-        lDD: lastUpdated ? pad(lastUpdated.getDate()) : "",
-        lD: lastUpdated ? "" + lastUpdated.getDate() : "",
-        lhh: lastUpdated ? pad(lastUpdated.getHours()) : "",
-        lh: lastUpdated ? "" + lastUpdated.getHours() : "",
-        lmm: lastUpdated ? pad(lastUpdated.getMinutes()) : "",
-        lm: lastUpdated ? "" + lastUpdated.getMinutes() : "",
-        lss: lastUpdated ? pad(lastUpdated.getSeconds()) : "",
-        ls: lastUpdated ? "" + lastUpdated.getSeconds() : "",
+  const pad = (n: number) => String(n).padStart(2, "0");
 
-        cYYYY: createdAt ? "" + createdAt.getFullYear() : "",
-        cYY: createdAt ? ("" + createdAt.getFullYear()).slice(-2) : "",
-        cMM: createdAt ? pad(createdAt.getMonth() + 1) : "",
-        cM: createdAt ? "" + (createdAt.getMonth() + 1) : "",
-        cDD: createdAt ? pad(createdAt.getDate()) : "",
-        cD: createdAt ? "" + createdAt.getDate() : "",
-        chh: createdAt ? pad(createdAt.getHours()) : "",
-        ch: createdAt ? "" + createdAt.getHours() : "",
-        cmm: createdAt ? pad(createdAt.getMinutes()) : "",
-        cm: createdAt ? "" + createdAt.getMinutes() : "",
-        css: createdAt ? pad(createdAt.getSeconds()) : "",
-        cs: createdAt ? "" + createdAt.getSeconds() : "",
-    };
+  const map: Record<string, string> = {
+    ":lYYYY": lastUpdated ? String(lastUpdated.getFullYear()) : "",
+    ":lYY": lastUpdated ? String(lastUpdated.getFullYear()).slice(-2) : "",
+    ":lMM": lastUpdated ? pad(lastUpdated.getMonth() + 1) : "",
+    ":lM": lastUpdated ? String(lastUpdated.getMonth() + 1) : "",
+    ":lDD": lastUpdated ? pad(lastUpdated.getDate()) : "",
+    ":lD": lastUpdated ? String(lastUpdated.getDate()) : "",
+    ":lhh": lastUpdated ? pad(lastUpdated.getHours()) : "",
+    ":lh": lastUpdated ? String(lastUpdated.getHours()) : "",
+    ":lmm": lastUpdated ? pad(lastUpdated.getMinutes()) : "",
+    ":lm": lastUpdated ? String(lastUpdated.getMinutes()) : "",
+    ":lss": lastUpdated ? pad(lastUpdated.getSeconds()) : "",
+    ":ls": lastUpdated ? String(lastUpdated.getSeconds()) : "",
 
-    return pattern.replace(
-        /\blYYYY\b|\blYY\b|\blMM\b|\blM\b|\blDD\b|\blD\b|\blhh\b|\blh\b|\blmm\b|\blm\b|\blss\b|\bls\b|\bcYYYY\b|\bcYY\b|\bcMM\b|\bcM\b|\bcDD\b|\bcD\b|\bchh\b|\bch\b|\bcmm\b|\bcm\b|\bcss\b|\bcs\b/g,
-        (match) => map[match] || ""
-    );
+    ":cYYYY": createdAt ? String(createdAt.getFullYear()) : "",
+    ":cYY": createdAt ? String(createdAt.getFullYear()).slice(-2) : "",
+    ":cMM": createdAt ? pad(createdAt.getMonth() + 1) : "",
+    ":cM": createdAt ? String(createdAt.getMonth() + 1) : "",
+    ":cDD": createdAt ? pad(createdAt.getDate()) : "",
+    ":cD": createdAt ? String(createdAt.getDate()) : "",
+    ":chh": createdAt ? pad(createdAt.getHours()) : "",
+    ":ch": createdAt ? String(createdAt.getHours()) : "",
+    ":cmm": createdAt ? pad(createdAt.getMinutes()) : "",
+    ":cm": createdAt ? String(createdAt.getMinutes()) : "",
+    ":css": createdAt ? pad(createdAt.getSeconds()) : "",
+    ":cs": createdAt ? String(createdAt.getSeconds()) : "",
+  };
+
+  const re = new RegExp(Object.keys(map).join("|"), "g");
+
+  return pattern.replace(re, match => map[match] || "");
 }

--- a/docs/.vitepress/theme/utils/common.ts
+++ b/docs/.vitepress/theme/utils/common.ts
@@ -40,21 +40,44 @@ export function resolveNavigationInput(input: any): { text?: string; link?: stri
 }
 
 
-function formatDate(date: Date, pattern: string): string {
-    const pad = (n: number) => n < 10 ? "0" + n : "" + n;
-    const replacements: Record<string, string> = {
-        ":YYYY": "" + date.getFullYear(),
-        ":YY": ("" + date.getFullYear()).slice(-2),
-        ":MM": pad(date.getMonth()+1),
-        ":M": "" + (date.getMonth()+1),
-        ":DD": pad(date.getDate()),
-        ":D": "" + date.getDate(),
-        ":hh": pad(date.getHours()),
-        ":h": "" + date.getHours(),
-        ":mm": pad(date.getMinutes()),
-        ":m": "" + date.getMinutes(),
-        ":ss": pad(date.getSeconds()),
-        ":s": "" + date.getSeconds()
+export function formatTimeLabel(
+    lastUpdated: Date | undefined,
+    createdAt: Date | undefined,
+    pattern: string
+): string | undefined {
+    if (!lastUpdated && !createdAt) return undefined;
+    const pad = (n: number) => (n < 10 ? "0" + n : "" + n);
+
+    const map: Record<string, string> = {
+        lYYYY: lastUpdated ? "" + lastUpdated.getFullYear() : "",
+        lYY: lastUpdated ? ("" + lastUpdated.getFullYear()).slice(-2) : "",
+        lMM: lastUpdated ? pad(lastUpdated.getMonth() + 1) : "",
+        lM: lastUpdated ? "" + (lastUpdated.getMonth() + 1) : "",
+        lDD: lastUpdated ? pad(lastUpdated.getDate()) : "",
+        lD: lastUpdated ? "" + lastUpdated.getDate() : "",
+        lhh: lastUpdated ? pad(lastUpdated.getHours()) : "",
+        lh: lastUpdated ? "" + lastUpdated.getHours() : "",
+        lmm: lastUpdated ? pad(lastUpdated.getMinutes()) : "",
+        lm: lastUpdated ? "" + lastUpdated.getMinutes() : "",
+        lss: lastUpdated ? pad(lastUpdated.getSeconds()) : "",
+        ls: lastUpdated ? "" + lastUpdated.getSeconds() : "",
+
+        cYYYY: createdAt ? "" + createdAt.getFullYear() : "",
+        cYY: createdAt ? ("" + createdAt.getFullYear()).slice(-2) : "",
+        cMM: createdAt ? pad(createdAt.getMonth() + 1) : "",
+        cM: createdAt ? "" + (createdAt.getMonth() + 1) : "",
+        cDD: createdAt ? pad(createdAt.getDate()) : "",
+        cD: createdAt ? "" + createdAt.getDate() : "",
+        chh: createdAt ? pad(createdAt.getHours()) : "",
+        ch: createdAt ? "" + createdAt.getHours() : "",
+        cmm: createdAt ? pad(createdAt.getMinutes()) : "",
+        cm: createdAt ? "" + createdAt.getMinutes() : "",
+        css: createdAt ? pad(createdAt.getSeconds()) : "",
+        cs: createdAt ? "" + createdAt.getSeconds() : "",
     };
-    return pattern.replace(/:YYYY|:YY|:MM|:M|:DD|:D|:hh|:h|:mm|:m|:ss|:s/g, match => replacements[match]);
+
+    return pattern.replace(
+        /\blYYYY\b|\blYY\b|\blMM\b|\blM\b|\blDD\b|\blD\b|\blhh\b|\blh\b|\blmm\b|\blm\b|\blss\b|\bls\b|\bcYYYY\b|\bcYY\b|\bcMM\b|\bcM\b|\bcDD\b|\bcD\b|\bchh\b|\bch\b|\bcmm\b|\bcm\b|\bcss\b|\bcs\b/g,
+        (match) => map[match] || ""
+    );
 }

--- a/docs/.vitepress/theme/utils/common.ts
+++ b/docs/.vitepress/theme/utils/common.ts
@@ -41,43 +41,68 @@ export function resolveNavigationInput(input: any): { text?: string; link?: stri
 
 
 export function formatTimeLabel(
-  lastUpdated: Date | undefined,
-  createdAt: Date | undefined,
-  pattern: string
+    lastUpdated: Date | undefined,
+    createdAt: Date | undefined,
+    pattern: string
 ): string | undefined {
-  if (!lastUpdated && !createdAt) return undefined;
+    if (!lastUpdated && !createdAt) return undefined;
 
-  const pad = (n: number) => String(n).padStart(2, "0");
+    const pad = (n: number) => String(n).padStart(2, "0");
 
-  const map: Record<string, string> = {
-    ":lYYYY": lastUpdated ? String(lastUpdated.getFullYear()) : "",
-    ":lYY": lastUpdated ? String(lastUpdated.getFullYear()).slice(-2) : "",
-    ":lMM": lastUpdated ? pad(lastUpdated.getMonth() + 1) : "",
-    ":lM": lastUpdated ? String(lastUpdated.getMonth() + 1) : "",
-    ":lDD": lastUpdated ? pad(lastUpdated.getDate()) : "",
-    ":lD": lastUpdated ? String(lastUpdated.getDate()) : "",
-    ":lhh": lastUpdated ? pad(lastUpdated.getHours()) : "",
-    ":lh": lastUpdated ? String(lastUpdated.getHours()) : "",
-    ":lmm": lastUpdated ? pad(lastUpdated.getMinutes()) : "",
-    ":lm": lastUpdated ? String(lastUpdated.getMinutes()) : "",
-    ":lss": lastUpdated ? pad(lastUpdated.getSeconds()) : "",
-    ":ls": lastUpdated ? String(lastUpdated.getSeconds()) : "",
+    const map: Record<string, string> = {
+        ":lYYYY": lastUpdated ? String(lastUpdated.getFullYear()) : "",
+        ":lYY": lastUpdated ? String(lastUpdated.getFullYear()).slice(-2) : "",
+        ":lMM": lastUpdated ? pad(lastUpdated.getMonth() + 1) : "",
+        ":lM": lastUpdated ? String(lastUpdated.getMonth() + 1) : "",
+        ":lDD": lastUpdated ? pad(lastUpdated.getDate()) : "",
+        ":lD": lastUpdated ? String(lastUpdated.getDate()) : "",
+        ":lhh": lastUpdated ? pad(lastUpdated.getHours()) : "",
+        ":lh": lastUpdated ? String(lastUpdated.getHours()) : "",
+        ":lmm": lastUpdated ? pad(lastUpdated.getMinutes()) : "",
+        ":lm": lastUpdated ? String(lastUpdated.getMinutes()) : "",
+        ":lss": lastUpdated ? pad(lastUpdated.getSeconds()) : "",
+        ":ls": lastUpdated ? String(lastUpdated.getSeconds()) : "",
 
-    ":cYYYY": createdAt ? String(createdAt.getFullYear()) : "",
-    ":cYY": createdAt ? String(createdAt.getFullYear()).slice(-2) : "",
-    ":cMM": createdAt ? pad(createdAt.getMonth() + 1) : "",
-    ":cM": createdAt ? String(createdAt.getMonth() + 1) : "",
-    ":cDD": createdAt ? pad(createdAt.getDate()) : "",
-    ":cD": createdAt ? String(createdAt.getDate()) : "",
-    ":chh": createdAt ? pad(createdAt.getHours()) : "",
-    ":ch": createdAt ? String(createdAt.getHours()) : "",
-    ":cmm": createdAt ? pad(createdAt.getMinutes()) : "",
-    ":cm": createdAt ? String(createdAt.getMinutes()) : "",
-    ":css": createdAt ? pad(createdAt.getSeconds()) : "",
-    ":cs": createdAt ? String(createdAt.getSeconds()) : "",
-  };
+        ":cYYYY": createdAt ? String(createdAt.getFullYear()) : "",
+        ":cYY": createdAt ? String(createdAt.getFullYear()).slice(-2) : "",
+        ":cMM": createdAt ? pad(createdAt.getMonth() + 1) : "",
+        ":cM": createdAt ? String(createdAt.getMonth() + 1) : "",
+        ":cDD": createdAt ? pad(createdAt.getDate()) : "",
+        ":cD": createdAt ? String(createdAt.getDate()) : "",
+        ":chh": createdAt ? pad(createdAt.getHours()) : "",
+        ":ch": createdAt ? String(createdAt.getHours()) : "",
+        ":cmm": createdAt ? pad(createdAt.getMinutes()) : "",
+        ":cm": createdAt ? String(createdAt.getMinutes()) : "",
+        ":css": createdAt ? pad(createdAt.getSeconds()) : "",
+        ":cs": createdAt ? String(createdAt.getSeconds()) : "",
+    };
 
-  const re = new RegExp(Object.keys(map).join("|"), "g");
+    const re = new RegExp(Object.keys(map).join("|"), "g");
 
-  return pattern.replace(re, match => map[match] || "");
+    return pattern.replace(re, match => map[match] || "");
+}
+
+export function formatDate(date: Date, pattern: string) {
+    if (!date) return undefined;
+
+    const pad = (n: number) => String(n).padStart(2, "0");
+
+    const map: Record<string, string> = {
+        ":YYYY": String(date.getFullYear()),
+        ":YY": String(date.getFullYear()).slice(-2),
+        ":MM": pad(date.getMonth() + 1),
+        ":M": String(date.getMonth() + 1),
+        ":DD": pad(date.getDate()),
+        ":D": String(date.getDate()),
+        ":hh": pad(date.getHours()),
+        ":h": String(date.getHours()),
+        ":mm": pad(date.getMinutes()),
+        ":m": String(date.getMinutes()),
+        ":ss": pad(date.getSeconds()),
+        ":s": String(date.getSeconds()),
+    };
+
+    const re = new RegExp(Object.keys(map).join("|"), "g");
+
+    return pattern.replace(re, match => map[match] || "");
 }

--- a/docs/about/about1.md
+++ b/docs/about/about1.md
@@ -1,0 +1,16 @@
+---
+layout: blog
+---
+
+<script setup>
+import { storeToRefs } from 'pinia';
+import { useVPJLayout } from '../.vitepress/theme/composables/useVPJLayout';
+
+
+const store = useVPJLayout();
+const { panelToggle } = store;
+</script>
+
+# 没git记录的博客
+
+<button @click="() => panelToggle('history')">点击我展开面板</button>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,12 @@ layout: page
 title: 主页
 ---
 <script setup>
+import { storeToRefs } from 'pinia';
+import { useVPJLayout } from './.vitepress/theme/composables/useVPJLayout';
+
+
+const store = useVPJLayout();
+const { panelToggle } = store;
 </script>
 
 <style scoped>
@@ -46,14 +52,14 @@ title: 主页
     <div class="hero-content">
         <h1>这是Cell的网站</h1>
         <h3>欢迎每一个访客</h3>
-        <button class="button">点击我</button>
+        <button class="button" @click="() => panelToggle('history')">点击我展开面板</button>
     </div>
 </VPJHeroImage>
 
 
 # 这是一个主页（绝赞装修中）
 
-我现在正在测试超赞的markdown样式，你可以在这里看到我的进度 [传送门](test/markdown-style.md)。
+我现在正在测试超赞的markdown样式，你可以在这里看到我的进度 [传送门](test/markdown-style.md)。啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊燕人张飞在此。
 
 ## 我的博客
 


### PR DESCRIPTION
# Juicy主题更新

## 更新梗概与演示

本次更新添加了基于`git log`的自动追踪更新逻辑，主要包含两个内容：

1. 模仿gitbook界面的历史记录追踪面板：

![历史记录演示](https://github.com/user-attachments/assets/972edfe3-b785-49d6-9f74-9669ec5a0f06)

可以和默认主题一样通过在vitepress的配置文件`.vitepress/config.ts`中启用`lastUpdated: true`来开启此功能，它会启用一个数据加载文件通过`git log`指令获取项目中markdown页面的历史提交记录。目前还在考虑此面板的展示效果，可能以后评估它对弹性布局的影响后会修改，现在还是按gitbook原先的展示逻辑放置的。

这个获取的方法参考了网络上的一篇博客：[唯知笔记](https://note.weizwz.com/vitepress/extend/post-data#%E5%8F%A6%E4%B8%80%E7%A7%8D%E6%80%9D%E8%B7%AF-%E7%94%9F%E6%88%90-json-%E6%96%87%E4%BB%B6)。

2. `blog`/`doc`页的时间标签

<img width="1035" height="241" alt="主页 _ Cell的个人站点 - Google Chrome 2025_8_26 15_49_07" src="https://github.com/user-attachments/assets/9c175acc-a9b1-4bf9-acad-03668fe826a4" />

在桌面端我们将它放在了每页的页脚处，如图所示可以自行设置文本的展示格式（依据最后更新时间与创建时间生成）。出于弹性布局的考虑在移动端我们将它放到了头部：

<img width="1107" height="260" alt="这是一个博客的示范页 _ Cell的个人站点 - Google Chrome 2025_8_26 15_50_09" src="https://github.com/user-attachments/assets/12197957-8e9b-4463-9961-bc0011b6e92c" />

时间标签不依赖于之前提到的自动追踪，出于自定义的考虑仍然可以通过页面frontmatter覆盖每个页面的`lastUpdated`与`createdAt`（如果启用了自动追踪，那么它会为每个没手动添加的页面自动依据历史记录寻找第一/最后一条的时间附加上去）。

本次更新没有加接口注释，有一些考量（参见开发想法区域）。

## 本次更新的内容

* [x] 添加了基于`git log`的自动追踪获取更新创建时间逻辑。
* [x] 添加了`blog`/`doc`布局配置时间标签的相关逻辑。

## 目前还需要开发的内容

* [ ] 国际化适配（现有历史记录面板是无法用配置简单修改单项文本的）
* [ ] 更精细的配置项
* [ ] 接口注释的迁移

## 未来的开发想法

嗯，大概就是一次很粗糙的更新，就可以在代码里看见的本次更新确实是欠缺很多内容需要补全的，主要是我对这个功能确实比较需要所以抢先上了再说，然后是照例列一下计划，其实和[Refactor/sidebar structure #16](https://github.com/cell-juicy/cell-juicy.github.io/pull/16)写的差不多，就是再列一下别忘了。

主要方向：

1. 主题功能

次要方向：

1. 搜索功能
2. 评论功能
3. 国际化适配

然后就是这次开发遇到的问题了，现行的useBlogData和useDocData遇到了和之前两个store版本一样的问题，就是太臃肿了，使用起来不方便并且可以显著观察到存在大量重复逻辑，所以主要方向以后还要加两次代码重构，大概是这几个方面：

2. 合并函数重构（不影响使用，只是单纯的优化代码）
3. 合并useBlogData和useDocData（估计和以前useVPJDocLayout与useVPJBlogLayout合并类似一样会改名叫`useVPJData()`，这会影响主题的使用），会为page布局做更多的功能附加，以及补全这次历史记录相关的配置项缺失的问题（因为和这个重构会相关所以这次的主题配置接口只是个半成品也没有添加注释）。

然后就是关于接口注释，虽然大部分靠AI写不算费力，但是现在这个大小有点太搞了（孩子们已经1k7行代码了，这并不好笑），我自己翻着都费劲，之后的时间里我应该会把接口注释一部分的转移到站点里以文章的形式保存（嗯大概就是单开一个doc space）。

然后主要的三个目标做完之后我可能会去先发个模板库，毕竟做完这些基本上就是半个功能完善的主题可以投入使用了，如果要用现版本也可以直接下载主题文件夹放进自己项目用。

嗯大概就是这样，梦到哪句说哪句，先发上来试试看云端部署效果。

